### PR TITLE
Clarify _Atomic tradeoff and add migration diff in PHILOSOPHY.md

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -76,6 +76,24 @@ writing, one reader in the main loop) because there is no cache coherency issue 
 the compiler is prevented from caching the values in registers. It is NOT sufficient
 for multi-core — use `_Atomic` (C11) or explicit platform memory barriers there.
 
+`_Atomic` is available (the library compiles with `-std=c11`) but deliberately not
+used by default: atomic operations imply memory barriers, which add overhead even
+when running on a single core. On a microcontroller where SPSC with an ISR is the
+common case, that cost is unnecessary.
+
+If you need multi-core safety, the change is a two-line diff in the struct:
+
+```diff
+-    volatile size_t head;
+-    volatile size_t tail;
++    _Atomic size_t head;
++    _Atomic size_t tail;
+```
+
+`_Atomic` subsumes `volatile`, so the qualifier can be dropped. Plain reads and
+writes to `_Atomic` types use sequentially consistent ordering in C11, which is
+correct (if slightly stronger than strictly necessary) for SPSC.
+
 See [`DESIGN.md`](DESIGN.md#virtual-index-approach-for-lock-free-fullempty-detection)
 for the full technical explanation, and [`HISTORY.md`](HISTORY.md#lock-free-redesign-virtual-index-approach)
 for the background.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,17 @@ the compiler from caching them in registers — correct for this use case.
 
 This is **not** sufficient for multi-core or multi-producer scenarios.
 Use `_Atomic` (C11) or platform memory barriers there, or switch to an
-RTOS queue. See [`PHILOSOPHY.md`](PHILOSOPHY.md) for the full rationale.
+RTOS queue. The change is a two-line diff in the struct:
+
+```diff
+-    volatile size_t head;
+-    volatile size_t tail;
++    _Atomic size_t head;
++    _Atomic size_t tail;
+```
+
+`_Atomic` subsumes `volatile`, so the qualifier can be dropped.
+See [`PHILOSOPHY.md`](PHILOSOPHY.md) for the full rationale.
 
 ## Memory Layout
 


### PR DESCRIPTION
Carry-over from PR #4 that was merged before this commit landed.

## Summary

- Explains that `_Atomic` is available (C11) but omitted by default because atomic ops imply memory barriers — unnecessary overhead for the common single-core SPSC case
- Adds a two-line diff showing exactly how to switch for multi-core use
- Notes that `_Atomic` subsumes `volatile` so the qualifier can be dropped

https://claude.ai/code/session_01Dr6jrvmwmoXi7QkiAGTvzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr6jrvmwmoXi7QkiAGTvzX)_